### PR TITLE
add for rest api to get last certificate for given userid

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -81,6 +81,13 @@ type ReenrollmentRequest struct {
 	CAName string `json:"caname,omitempty" skip:"true"`
 }
 
+// UserECertRequest is a request about the certificate for user
+type UserECertRequest struct {
+	// The identity name to request a certificate
+	Name string `json:"name"`
+}
+
+
 // RevocationRequest is a revocation request for a single certificate or all certificates
 // associated with an identity.
 // To revoke a single certificate, both the Serial and AKI fields must be set;

--- a/lib/certdbaccessor.go
+++ b/lib/certdbaccessor.go
@@ -41,6 +41,10 @@ INSERT INTO certificates (id, serial_number, authority_key_identifier, ca_label,
 SELECT %s FROM certificates
 WHERE (id = ?);`
 
+	selectLast1SQLbyID = `
+SELECT %s FROM certificates
+WHERE (id = ?) order by expiry desc limit 1;`
+
 	selectSQL = `
 SELECT %s FROM certificates
 WHERE (serial_number = ? AND authority_key_identifier = ?);`
@@ -147,6 +151,22 @@ func (d *CertDBAccessor) GetCertificatesByID(id string) (crs []CertRecord, err e
 	err = d.db.Select(&crs, fmt.Sprintf(d.db.Rebind(selectSQLbyID), sqlstruct.Columns(CertRecord{})), id)
 	if err != nil {
 		return nil, err
+	}
+
+	return crs, nil
+}
+
+// GetLastCertificatesByID gets a CertificateRecord indexed by id.
+func (d *CertDBAccessor) GetLastCertificatesByID(id string) (crs []CertRecord, err error) {
+	log.Debugf("DB: Get last certificate by ID (%s)", id)
+	err = d.checkDB()
+	if err != nil {
+		return crs, err
+	}
+
+	err = d.db.Select(&crs, fmt.Sprintf(d.db.Rebind(selectLast1SQLbyID), sqlstruct.Columns(CertRecord{})), id)
+	if err != nil {
+		return crs, err
 	}
 
 	return crs, nil

--- a/lib/server.go
+++ b/lib/server.go
@@ -374,6 +374,7 @@ func (s *Server) registerHandlers() {
 	s.registerHandler("reenroll", newReenrollHandler, token)
 	s.registerHandler("revoke", newRevokeHandler, token)
 	s.registerHandler("tcert", newTCertHandler, token)
+	s.registerHandler("ecert", newECertHandler, noAuth)
 }
 
 // Register an endpoint handler

--- a/lib/serverecert.go
+++ b/lib/serverecert.go
@@ -1,0 +1,96 @@
+/*
+Copyright IBM Corp. 2017 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+                 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib
+
+import (
+	"net/http"
+	"encoding/json"
+
+	cfapi "github.com/cloudflare/cfssl/api"
+	"github.com/cloudflare/cfssl/log"
+	"io/ioutil"
+	"github.com/hyperledger/fabric-ca/api"
+
+)
+
+// infoHandler handles the GET /info request
+type ecertHandler struct {
+	server *Server
+}
+
+// newInfoHandler is the constructor for the infoHandler
+func newECertHandler(server *Server) (h http.Handler, err error) {
+	return &cfapi.HTTPHandler{
+		Handler: &ecertHandler{server: server},
+		Methods: []string{"POST"},
+	}, nil
+}
+
+// The response to the GET /info request
+type serverECertNet struct {
+	// user id
+	Name string
+	// Base64 encoding of PEM-encoded certificate chain
+	Certificate string
+}
+
+// Handle is the handler for the GET /info request
+func (eh *ecertHandler) Handle(w http.ResponseWriter, r *http.Request) error {
+	log.Debug("Received request for user certificate")
+
+	// Read the request's body
+	reqBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	r.Body.Close()
+
+	// Unmarshall the request body
+	var req api.UserECertRequest
+	err = json.Unmarshal(reqBody, &req)
+	if err != nil {
+		log.Info(reqBody)
+		log.Error(err.Error())
+		return err
+	}
+
+	log.Debugf("ECert request: %+v\n", req)
+	log.Infof("Requested userid: %s\n", req.Name)
+
+	pem, err := eh.getUserLastCertificate(req.Name)
+	if err != nil {
+		log.Error(err.Error())
+		return err
+	}
+	log.Infof("Cert: %s\n", pem)
+	//resp := &serverECertNet{req.Name, util.B64Encode(pem)}
+	resp := &serverECertNet{req.Name, pem}
+	return cfapi.SendResponse(w, resp)
+}
+
+// getUserLastCertificate return a user's last certificate
+func (eh *ecertHandler) getUserLastCertificate(username string) (string, error) {
+	log.Debug("getUserLastCertificate user=%s", username)
+	//crs []CertRecord
+	crs, err := eh.server.certDBAccessor.GetLastCertificatesByID(username)
+	if err != nil {
+		return "", err
+	}
+
+	log.Debug("getUserLastCertificate user=%s, certificate=%", username, crs[0].CertificateRecord.PEM)
+	return crs[0].CertificateRecord.PEM, nil
+}


### PR DESCRIPTION
In some cases, fabric members need to get the certificate of other members, not ca certificate.
So I appended the rest api to retrieve the certificate by user id.